### PR TITLE
Add wire:navigate to docs

### DIFF
--- a/app/Domain/Docs/WireNavigateExtension.php
+++ b/app/Domain/Docs/WireNavigateExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Domain\Docs;
+
+use Exception;
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
+use League\CommonMark\Extension\CommonMark\Renderer\Inline\LinkRenderer;
+use League\CommonMark\Extension\ExtensionInterface;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
+use League\Config\ConfigurationAwareInterface;
+use League\Config\ConfigurationInterface;
+use Spatie\Url\Url;
+
+class WireNavigateExtension implements ExtensionInterface, NodeRendererInterface, ConfigurationAwareInterface
+{
+    private ConfigurationInterface $configuration;
+
+    public function register(EnvironmentBuilderInterface $environment): void
+    {
+        $environment->addRenderer(Link::class, $this, 10);
+    }
+
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer)
+    {
+        if (! $node instanceof Link) {
+            throw new Exception('Unsupported node');
+        }
+
+        $url = Url::fromString($node->getUrl());
+
+        if ($url->getFirstSegment() === 'docs') {
+            $node->data->set(
+                'attributes',
+                array_merge($node->data->get('attributes'), ['wire:navigate' => true]),
+            );
+        }
+
+
+        $renderer = new LinkRenderer();
+        $renderer->setConfiguration($this->configuration);
+
+        return $renderer->render($node, $childRenderer);
+    }
+
+    public function setConfiguration(ConfigurationInterface $configuration): void
+    {
+        $this->configuration = $configuration;
+    }
+}

--- a/config/markdown.php
+++ b/config/markdown.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Domain\Docs\BladeParsingExtension;
+use App\Domain\Docs\WireNavigateExtension;
 use League\CommonMark\Normalizer\SlugNormalizer;
 use League\CommonMark\Util\HtmlFilter;
 
@@ -92,6 +93,7 @@ return [
         League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension::class,
         League\CommonMark\Extension\TableOfContents\TableOfContentsExtension::class,
         BladeParsingExtension::class,
+        WireNavigateExtension::class,
         League\CommonMark\Extension\Table\TableExtension::class,
     ],
 

--- a/resources/css/docs/content.css
+++ b/resources/css/docs/content.css
@@ -101,6 +101,11 @@
         min-width: 220px;
         margin-left: 100px;
         font-size: .7rem;
+        position: sticky;
+        top: 0;
+        height: 100vh;
+        overflow: auto;
+        padding-bottom: 1rem;
 
         display: none;
 

--- a/resources/views/components/docs-navigation.blade.php
+++ b/resources/views/components/docs-navigation.blade.php
@@ -1,4 +1,4 @@
-<nav class="docs-navigation" x-data="{navOpen: false}">
+<nav class="docs-navigation" x-data="{ navOpen: false }" x-on:livewire:navigated.window="navOpen = false">
     <button @click="navOpen = !navOpen" class="block lg:hidden w-full bg-white border-b px-5 py-4 text-left font-semibold text-base flex justify-between items-center">
         <span>Contents</span>
 

--- a/resources/views/front/layouts/docs.blade.php
+++ b/resources/views/front/layouts/docs.blade.php
@@ -4,7 +4,7 @@
     @include('partials.layout.head')
 </head>
 <body class="bg-white font-sans font-medium text-black docs">
-    <div class="border-b border-gray-200 bg-white relative z-50">
+    <div class="border-b border-gray-200 bg-white relative z-50" id="header">
         @include('partials.header')
     </div>
 
@@ -14,21 +14,66 @@
         </div>
 
         <div class="lg:flex">
-            <div class="border-r border-gray-200">
-                <x-docs-navigation></x-docs-navigation>
-            </div>
+            @persist('scrollbar')
+                <div class="border-r border-gray-200 sticky top-0 lg:h-screen overflow-y-scroll" wire:scroll>
+                    <x-docs-navigation></x-docs-navigation>
+                </div>
+            @endpersist
 
-            <section class="page-content lg:w-full p-5 lg:p-14">
+            <section class="page-content lg:w-full p-5 lg:p-14 lg:pb-24">
                 @yield('content')
-            </section>
-        </div>
 
-        <div class="absolute right-0 -bottom-4">
-            @include('partials.docs.ornament')
+                <div class="absolute right-0 bottom-24">
+                    @include('partials.docs.ornament')
+                </div>
+            </section>
         </div>
     </div>
 
-    @include('partials.footer')
+    <script>
+        document.addEventListener('alpine:init', () => {
+            let state = Alpine.reactive({ path: window.location.pathname });
+
+            function strip(path) {
+                parts = path.replace(/https?:\/\//, '').split('/');
+                parts.shift();
+
+                return parts.join('/');
+            }
+
+            function section(path) {
+                parts = path.split('/');
+                parts.pop();
+
+                return parts.join('/');
+            }
+
+            let scrollPosition = 0;
+
+            document.addEventListener('livewire:navigating', () => {
+                scrollPosition = document.documentElement.scrollTop || document.body.scrollTop;
+            });
+
+            document.addEventListener('livewire:navigated', () => {
+                queueMicrotask(() => {
+                    document.documentElement.scrollTop = document.body.scrollTop = Math.min(
+                        scrollPosition,
+                        document.getElementById('header').clientHeight,
+                    );
+
+                    state.path = window.location.pathname;
+                });
+            });
+
+            Alpine.magic('current', (el) => (expected = '') => {
+                return strip(state.path) === strip(expected);
+            });
+
+            Alpine.magic('currentSection', (el) => (expected = '') => {
+                return section(strip(state.path)) === section(strip(expected));
+            });
+        });
+    </script>
 
     @include('partials.layout.scripts')
 </body>

--- a/resources/views/partials/docs/navigation-category.blade.php
+++ b/resources/views/partials/docs/navigation-category.blade.php
@@ -1,6 +1,10 @@
 <div class="navigation-category">
-    <a href="{{$category->firstPage()->url}}" class="pl-0 cursor-pointer text-sm font-semibold">
-        {{$category->title}}
+    <a
+        href="{{$category->firstPage()->url }}"
+        class="pl-0 cursor-pointer text-sm font-semibold"
+        wire:navigate.hover
+    >
+        {{ $category->title }}
     </a>
     <ul>
         @foreach($category->categories as $subCategory)
@@ -9,17 +13,17 @@
             </li>
         @endforeach
         @foreach($category->pages as $page)
-            <li
+            <li x-bind:class="$current('{{ $page->url }}') ? 'active border-indigo-500' : ''"
                 @class([
                     'active border-indigo-500' => \Illuminate\Support\Str::contains($slug, $page->slug),
                 ])
             >
-                <a href="{{$page->url}}"
-                    @class([
-                        'active border-indigo-500 border-s' => \Illuminate\Support\Str::contains($slug, $page->slug),
-                    ])
+                <a
+                    href="{{ $page->url }}"
+                    x-bind:class="$current('{{ $page->url }}') ? 'active border-indigo-500 border-s' : ''"
+                    wire:navigate.hover
                 >
-                    {{$page->menuTitle()}}
+                    {{ $page->menuTitle() }}
                 </a>
             </li>
         @endforeach

--- a/resources/views/partials/docs/navigation-sub-category.blade.php
+++ b/resources/views/partials/docs/navigation-sub-category.blade.php
@@ -1,30 +1,27 @@
-<a href="{{$category->firstPage()->url}}"
-    @class([
-        '-left-px active border-l border-indigo-500 font-semibold text-indigo-500' => \Illuminate\Support\Str::contains($slug, $category->slug),
-    ])
+<a
+    href="{{ $category->firstPage()->url }}"
+    x-bind:class="$currentSection('{{ $category->firstPage()->url }}') ? '-left-px active border-l border-indigo-500 font-semibold text-indigo-500' : ''"
+    wire:navigate.hover
 >
-    {{$category->title}}
+    {{ $category->title }}
 </a>
-@if(\Illuminate\Support\Str::contains($slug, $category->slug))
-    <ul>
-
-            @foreach($category->categories as $subCategory)
-                <li>
-                    @include('partials.docs.navigation-sub-category', ['category' => $subCategory])
-                </li>
-            @endforeach
-            @if(count($category->pages) >= 2)
-                @foreach($category->pages as $page)
-                    <li>
-                        <a href="{{$page->url}}"
-                            @class([
-                                'active text-indigo-500' => \Illuminate\Support\Str::contains($slug, $page->slug),
-                            ])
-                        >
-                            {{$page->menuTitle()}}
-                        </a>
-                    </li>
-                @endforeach
-            @endif
-    </ul>
-@endif
+<ul x-show="$currentSection('{{ $category->firstPage()->url }}')">
+    @foreach($category->categories as $subCategory)
+        <li>
+            @include('partials.docs.navigation-sub-category', ['category' => $subCategory])
+        </li>
+    @endforeach
+    @if(count($category->pages) >= 2)
+        @foreach($category->pages as $page)
+            <li>
+                <a
+                    href="{{ $page->url }}"
+                    x-bind:class="$current('{{ $page->url }}') ?  'active text-indigo-500' : ''"
+                    wire:navigate.hover
+                >
+                    {{ $page->menuTitle() }}
+                </a>
+            </li>
+        @endforeach
+    @endif
+</ul>


### PR DESCRIPTION
Adds `wire:navigate` to the docs.

All the "current link" logic has been pulled to Alpine instead of the server so the sidebar scroll position can be persisted & updated on the client.

~This currently only works for the sidebar navigation, I don't know if there's a way to enable Livewire navigations for internal links in the Markdown content without having to write HTML hrefs in them.~ Added a CommonMark extension

I removed the footer because it looks better if the sidebar can span until the bottom of the page.