### PR TITLE
Update docker.md: 'him' -> 'it'

### DIFF
--- a/docs/environments/docker.md
+++ b/docs/environments/docker.md
@@ -91,7 +91,7 @@ Go to your SSH config:
 nano /etc/hosts/sshd_config
 ```
 
-Search for *GatewayPorts* and set him from **no** to **yes**
+Search for *GatewayPorts* and set it from **no** to **yes**
 ```text
 GatewayPorts yes
 ```


### PR DESCRIPTION
Corrected GatewayPorts configuration instruction by replacing ‘him’ with ‘it’ to avoid implying a human reference.