### PR TITLE
Fix language name

### DIFF
--- a/docs/other-languages/ruby/getting-started.md
+++ b/docs/other-languages/ruby/getting-started.md
@@ -3,7 +3,7 @@ title: Using Ray With Ruby
 weight: 1
 ---
 
-You can use Ray with Go via this third party package:
+You can use Ray with Ruby via this third party package:
 
 [spatie/ruby-ray](https://github.com/spatie/ruby-ray)
 


### PR DESCRIPTION
Correct language name on document for using Ruby. 