### PR TITLE
Add Dart integration

### DIFF
--- a/docs/other-languages/dart/_index.md
+++ b/docs/other-languages/dart/_index.md
@@ -1,0 +1,4 @@
+---
+title: Dart
+weight: 10
+---

--- a/docs/other-languages/dart/installation.md
+++ b/docs/other-languages/dart/installation.md
@@ -6,6 +6,7 @@ weight: 1
 You can send information from Dart to Ray via this third party package:
 
 Github: [neonarray/ray-dart](https://github.com/neonarray/ray-dart)
+
 Pub.dev: [ray_dart](https://pub.dev/packages/ray_dart)
 
 ## ray-dart

--- a/docs/other-languages/dart/installation.md
+++ b/docs/other-languages/dart/installation.md
@@ -5,7 +5,8 @@ weight: 1
 
 You can send information from Dart to Ray via this third party package:
 
-[neonarray/ray-dart](https://github.com/neonarray/ray-dart)
+Github: [neonarray/ray-dart](https://github.com/neonarray/ray-dart)
+Pub.dev: [ray_dart](https://pub.dev/packages/ray_dart)
 
 ## ray-dart
 

--- a/docs/other-languages/dart/installation.md
+++ b/docs/other-languages/dart/installation.md
@@ -1,0 +1,23 @@
+---
+title: Using Ray With Dart
+weight: 1
+---
+
+You can send information from Dart to Ray via this third party package:
+
+[neonarray/ray-dart](https://github.com/neonarray/ray-dart)
+
+## ray-dart
+
+Install the package normally with dart cli:
+
+```bash
+dart pub add ray_dart
+```
+
+…install it globally to be able to access it from any script/directory:
+
+```bash
+dart pub global activate ray_dart
+```
+


### PR DESCRIPTION
This PR adds Dart to the other languages section of the docs.

The package is: https://pub.dev/packages/ray_dart
The repo is: https://github.com/neonarray/ray-dart